### PR TITLE
Revert exclude_unset back to pydantic default

### DIFF
--- a/protobuf_to_pydantic/default_base_model.py
+++ b/protobuf_to_pydantic/default_base_model.py
@@ -121,9 +121,9 @@ class ProtobufCompatibleBaseModel(BaseModel):
         exclude: Optional[Any] = None,
         context: Optional[Dict[str, Any]] = None,
         by_alias: bool = False,
-        exclude_unset: bool = True,  # Changed default to True
-        exclude_defaults: bool = True,  # Changed default to True
-        exclude_none: bool = True,  # Changed default to True
+        exclude_unset: bool = False, # True will break Trajectory serialization  
+        exclude_defaults: bool = False,
+        exclude_none: bool = False, 
         round_trip: bool = False,
         warnings: bool = True,
         serialize_as_any: bool = False,


### PR DESCRIPTION
This is currently breaking trajectory serialization...

When some fields are removed there is problem with finding the right union type which will result in warnings like:

```
[/Users/chris/forge/pyforge/pipelines/.venv/lib/python3.12/site-packages/protobuf_to_pydantic/default_base_model.py:36](https://file+.vscode-resource.vscode-cdn.net/Users/chris/forge/pyforge/pipelines/.venv/lib/python3.12/site-packages/protobuf_to_pydantic/default_base_model.py:36): UserWarning: Pydantic serializer warnings:
  PydanticSerializationUnexpectedValue(Expected `EventPayloadAssistant_Message_End` - serialized value may not be as expected [field_name='payload', input_value=EventPayloadTool_Call_Inf...), prompt_token_ids=[])), input_type=EventPayloadTool_Call_Inference_Start])
  PydanticSerializationUnexpectedValue(Expected `EventPayloadCompression_Compact` - serialized value may not be as expected [field_name='payload', input_value=EventPayloadTool_Call_Inf...), prompt_token_ids=[])), input_type=EventPayloadTool_Call_Inference_Start])
  PydanticSerializationUnexpectedValue(Expected `EventPayloadModel_Reminder` - serialized value may not be as expected [field_name='payload', input_value=EventPayloadTool_Call_Inf...), prompt_token_ids=[])), input_type=EventPayloadTool_Call_Inference_Start])
  PydanticSerializationUnexpectedValue(Expected `EventPayloadSession_Input` - serialized value may not be as expected [field_name='payload', input_value=EventPayloadTool_Call_Inf...), prompt_token_ids=[])), input_type=EventPayloadTool_Call_Inference_Start])
  PydanticSerializationUnexpectedValue(Expected `EventPayloadSession_Start` - serialized value may not be as expected [field_name='payload', input_value=EventPayloadTool_Call_Inf...), prompt_token_ids=[])), input_type=EventPayloadTool_Call_Inference_Start])
  PydanticSerializationUnexpectedValue(Expected `EventPayloadThought_End` - serialized value may not be as expected [field_name='payload', input_value=EventPayloadTool_Call_Inf...), prompt_token_ids=[])), input_type=EventPayloadTool_Call_Inference_Start])
  PydanticSerializationUnexpectedValue(Expected `EventPayloadTool_Call_Inference_End` - serialized value may not be as expected [field_name='payload', input_value=EventPayloadTool_Call_Inf...), prompt_token_ids=[])), input_type=EventPayloadTool_Call_Inference_Start])
  PydanticSerializationUnexpectedValue(Expected 6 fields but got 2: Expected `ChatCompletionMessage` - serialized value may not be as expected [field_name='messages', input_value=ChatCompletionMessage(rol...nt='', content_parts=[]), input_type=ChatCompletionMessage])
  PydanticSerializationUnexpectedValue(Expected `EventPayloadTool_Call_Observation` - serialized value may not be as expected [field_name='payload', input_value=EventPayloadTool_Call_Inf...), prompt_token_ids=[])), input_type=EventPayloadTool_Call_Inference_Start])
  PydanticSerializationUnexpectedValue(Expected `EventPayloadTool_Call_Parsed` - serialized value may not be as expected [field_name='payload', input_value=EventPayloadTool_Call_Inf...), prompt_token_ids=[])), input_type=EventPayloadTool_Call_Inference_Start])
  PydanticSerializationUnexpectedValue(Expected `EventPayloadTool_Call_Result` - serialized value may not be as expected [field_name='payload', input_value=EventPayloadTool_Call_Inf...), prompt_token_ids=[])), input_type=EventPayloadTool_Call_Inference_Start])
  PydanticSerializationUnexpectedValue(Expected `EventPayloadNone` - serialized value may not be as expected [field_name='payload', input_value=EventPayloadTool_Call_Inf...), prompt_token_ids=[])), input_type=EventPayloadTool_Call_Inference_Start])
  output = nxt(self)
```

This fix will make sure calling trajectory.dump() does not exclude fields by default. Serialization time goes from 40s -> 65ms